### PR TITLE
Update actionResponses.js

### DIFF
--- a/components/actions/actionResponses.js
+++ b/components/actions/actionResponses.js
@@ -24,7 +24,7 @@ async function contribute(say) {
 
 async function helpWithWebsite(say) {
   return await say(
-    `You clicked *Help with the Website*\n first step is getting to know our community! You can connect with us in any of the ways described in our Participate page here: https://chaoss.community/participate.
+    `You clicked *Help with the Website*\n first step is getting to know our community! You can connect with us in any of the ways described in our Participate page here: https://chaoss.community/kb-getting-started/.
     `
   );
 }


### PR DESCRIPTION
I substituted the original link (https://chaoss.community/participate) with a different link (https://chaoss.community/kb-getting-started/) due to the initial link being broken. When clicked, it resulted in a 404 error.

This PR...

## Changes on line 27 in  actionResponses.js file

Fixes #64